### PR TITLE
v1.0.1

### DIFF
--- a/MAX17055.device.lib.nut
+++ b/MAX17055.device.lib.nut
@@ -246,7 +246,7 @@ class MAX17055 {
         // ModelGauge Register Standard Resolutions Table
         // Percent 1/256%, Capacity 5.0μVH/ R_SENSE
         local percent  = _readReg(MAX17055_REP_SOC_REG);
-        percent /= 256;
+        percent /= 256.0;
         local capacity = _readReg(MAX17055_REP_CAP_REG);
         capacity = _twosComp(capacity);
         // Convert to mAh

--- a/MAX17055.device.lib.nut
+++ b/MAX17055.device.lib.nut
@@ -358,10 +358,11 @@ class MAX17055 {
     }
 
     function _verify(reg, value, next) {
+        local actual;
         try {
             _writeReg(reg, value);
             imp.sleep(MAX17055_REG_VERIFY_TIMEOUT_SEC);
-            local actual = _readReg(reg);
+            actual = _readReg(reg);
         } catch (err) {
             return _handleErr(error, next);
         }

--- a/MAX17055.device.lib.nut
+++ b/MAX17055.device.lib.nut
@@ -215,7 +215,6 @@ class MAX17055 {
         return (ttf * 5.625 / 3600);
     }
 
-
     function getAvgCurrent() {
         // Register values calculated based on (datasheet table 6)
         // ModelGauge Register Standard Resolutions Table
@@ -337,7 +336,7 @@ class MAX17055 {
 
     function _regReady(reg, mask, expected, next) {
         local val = _readReg(reg, false);
-        if (val && (val & mask) == expected) {
+        if (val != null && (val & mask) == expected) {
             _regReadyCounter = 0;
             next(null);
         } else {

--- a/MAX17055.device.lib.nut
+++ b/MAX17055.device.lib.nut
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright 2015-2017 Electric Imp
+// Copyright 2018 Electric Imp
 //
 // SPDX-License-Identifier: MIT
 //
@@ -75,7 +75,7 @@ enum MAX17055_BATT_TYPE {
 
 class MAX17055 {
 
-    static VERSION = "1.0.0";
+    static VERSION = "1.0.1";
 
     _i2c  = null;
     _addr = null;

--- a/MAX17055.device.lib.nut
+++ b/MAX17055.device.lib.nut
@@ -46,7 +46,7 @@ const MAX17055_DQ_ACC_REG             = 0x45;
 const MAX17055_DP_ACC_REG             = 0x46;
 const MAX17055_SOFT_WAKE_CMD_REG      = 0x60;
 const MAX17055_I_ALRT_TH_REG          = 0xB4;
-const MAX17055_HIB_CGF_REG            = 0xBA;
+const MAX17055_HIB_CFG_REG            = 0xBA;
 const MAX17055_CONFIG_2_REG           = 0xBB;
 const MAX17055_MODEL_CFG_REG          = 0xDB;
 
@@ -123,15 +123,15 @@ class MAX17055 {
                 // Catch any i2c read/write errors
                 try {
                     // Store Hibernate Configuration
-                    hibCfg = _readReg(MAX17055_HIB_CGF_REG);
+                    hibCfg = _readReg(MAX17055_HIB_CFG_REG);
 
                     // Exit Hibernate mode
                     _writeReg(MAX17055_SOFT_WAKE_CMD_REG, MAX17055_SOFT_WAKE_CMD_WAKE);
-                    _writeReg(MAX17055_HIB_CGF_REG, MAX17055_HIBERNATE_CMD_CLEAR);
+                    _writeReg(MAX17055_HIB_CFG_REG, MAX17055_HIBERNATE_CMD_CLEAR);
                     _writeReg(MAX17055_SOFT_WAKE_CMD_REG, MAX17055_SOFT_WAKE_CMD_CLEAR);
 
                     // Set Battery Config - these must be passed in
-                    local desCap = (settings.desCap * _capacityLSB).tointeger();
+                    local desCap = (settings.desCap / _capacityLSB).tointeger();
 
                     _writeReg(MAX17055_DESIGN_CAP_REG, desCap);
                     _writeReg(MAX17055_DQ_ACC_REG, (desCap / 32));
@@ -163,7 +163,7 @@ class MAX17055 {
                     if (er) return _handleErr(er, cb);
                     try {
                         // Reset original values of Hibernate Configuration
-                        _writeReg(MAX17055_HIB_CGF_REG, hibCfg);
+                        _writeReg(MAX17055_HIB_CFG_REG, hibCfg);
                         // Clear POR aler bit
                         _writeVerify(MAX17055_STATUS_REG, 0xFFFD, cb);
                     } catch(e) {
@@ -409,11 +409,7 @@ class MAX17055 {
     }
 
     function _twosComp(value) {
-        if (value & 0x8000) {
-            value = ~(value & 0x7FFF) + 1;
-            return -1 * (value & 0x7FFF);
-        }
-        return value;
+        return (value << 16) >> 16;
     }
 
 }

--- a/MAX17055.device.lib.nut
+++ b/MAX17055.device.lib.nut
@@ -158,7 +158,7 @@ class MAX17055 {
                 }
 
                 // Wait for refresh bit to clear (bit 15)
-                _regReady(MAX17055_MODEL_CFG_REG, 0x1000, 0, function(er) {
+                _regReady(MAX17055_MODEL_CFG_REG, 0x8000, 0, function(er) {
                     // Pass error to callback if we don't get expected value after multiple re-checks
                     if (er) return _handleErr(er, cb);
                     try {
@@ -320,7 +320,7 @@ class MAX17055 {
         // ModelGauge Register Standard Resolutions Table
         // Capacity 5.0μVH/ R_SENSE, Current 1.5625μV/R_SENSE
 
-        // Convert from micro to milli
+        // Convert from ohms to milli
         local res = res * 1000;
         // LSB vals in millis
         _capacityLSB = (5.0 / res);

--- a/README.md
+++ b/README.md
@@ -1,10 +1,8 @@
 # MAX17055 #
 
-The MAX17055 is a low power fuel gauge IC that implements Maxim ModelGauge m5 EZ algorithm. It measures voltage, current, and temperature to produce fuel gauge results. Typical power consumption is 7μA.
+The MAX17055 is a low-power fuel-gauge IC that implements the [Maxim ModelGauge m5 EZ algorithm](https://www.maximintegrated.com/en/design/partners-and-technology/design-technology/modelgauge-battery-fuel-gauge-technology.html). It measures battery voltage, current and temperature to produce fuel gauge results. Its typical power consumption is 7μA.
 
-**To add this library to your project, add the following to the top of your device code:**
-
-`#require "MAX17055.device.lib.nut:1.0.1"`
+**To add this library to your project, add** `#require "MAX17055.device.lib.nut:1.0.0"` **to the top of your device code.**
 
 ## Class Usage ##
 
@@ -14,17 +12,19 @@ The MAX17055 is a low power fuel gauge IC that implements Maxim ModelGauge m5 EZ
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
-| *i2cBus* | i2c bus object | Yes | The imp i2c bus that the fuel gauge is wired to. The i2c bus must be preconfigured. The library will not configure the bus. |
-| *i2cAddress* | integer | No | The i2c address of the fuel gauge. Default value is `0x6C` |
+| *i2cBus* | imp i2c bus object | Yes | The imp i2c bus that the fuel gauge is connected to. The i2c bus **must** be preconfigured; the library will not configure the bus |
+| *i2cAddress* | Integer | No | The i2c address of the fuel gauge. Default: `0x6C` |
 
 #### Return Value ####
 
-None.
+Nothing.
 
 #### Example ####
 
 ```squirrel
-local i2c = hardware.i2cKL
+#require "MAX17055.device.lib.nut:1.0.0"
+
+local i2c = hardware.i2cKL;
 i2c.configure(CLOCK_SPEED_400_KHZ);
 fuelGauge <- MAX17055(i2c);
 ```
@@ -33,66 +33,61 @@ fuelGauge <- MAX17055(i2c);
 
 ### init(*settings[, callback]*) ###
 
-Initializes the fuel gauge. If a power on reset alert is detected the *settings* parameter will be used to configure the fuel gauge. Initialization is an asynchonous process, the optional callback funciton will be triggered when initialization is complete.
-
+This method initializes the fuel gauge. If a power on reset alert is detected, the *settings* parameter will be used to re-configure the fuel gauge. Initialization is an asynchronous process; the optional callback function, if provided, will be triggered when initialization is complete.
 
 #### Parameters ####
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
-| *settings* | table | Yes | A table with the configuration settings. See below. |
-| *callback* | function | No | Function that is triggered when initialization is complete. The *callback* function takes one required parameter that contains an error string if an error was encountered while initializing otherwise the parameter will be `null`. |
+| *settings* | Table | Yes | A table of configuration settings *(see below)* |
+| *callback* | Function | No | A function that will be triggered when initialization is complete. It has one (required) parameter of its own which will receive an error message string if an error was encountered during initializion, otherwise `null` |
 
-##### Settings Table #####
+#### Settings Table Options ####
 
-| Slot Name | Type | Required | Description |
+| Key | Type | Required | Description |
 | --- | --- | --- | --- |
-| *desCap* | integer | Yes | The designed capacity of the battery in mAh. |
-| *senseRes* | float | Yes | The size of the sense resistor in ohms. |
-| *chrgTerm* | integer | Yes | The battery's termination charge in mA. |
-| *emptyVTarget* | float | Yes | The empty target voltage. Resolution is 10mV the value should be given in Volts. |
-| *recoveryV* | float | Yes | Once the cell voltage rises above this point, empty voltage detection is reenabled. Resolution is 40mV the value should be given in Volts. |
-| *chrgV* | integer | Yes | The charge voltage. Use class constants: *MAX17055_V_CHRG_4_2* (4.2V) or *MAX17055_V_CHRG_4_4_OR_4_35* (4.35V or 4.4V). |
-| *battType* | integer | Yes | Select the type of battery from the following class enum: *MAX17055_BATT_TYPE.LiCoO2* (most common), *MAX17055_BATT_TYPE.NCA_NCR*, or *MAX17055_BATT_TYPE.LiFePO4*. |
+| *desCap* | Integer | Yes | The designed capacity of the battery in mAh |
+| *senseRes* | Float | Yes | The size of the sense resistor in &Omega; |
+| *chrgTerm* | Integer | Yes | The battery's termination charge in mA |
+| *emptyVTarget* | Float | Yes | The empty target voltage in V. Resolution is 10mV |
+| *recoveryV* | Float | Yes | A recovery voltage in V. Once the cell voltage rises above this point, empty voltage detection is re-enabled. Resolution is 40mV |
+| *chrgV* | Integer | Yes | The charge voltage. Use the class constants *MAX17055_V_CHRG_4_2* (4.2V) or *MAX17055_V_CHRG_4_4_OR_4_35* (4.35V or 4.4V) |
+| *battType* | Integer | Yes | Select the type of battery from the following class enum: *MAX17055_BATT_TYPE.LiCoO2* (most common), *MAX17055_BATT_TYPE.NCA_NCR* or *MAX17055_BATT_TYPE.LiFePO4* |
 
 #### Return Value ####
 
-None.
+Nothing.
 
 #### Example ####
 
 ```squirrel
 local settings = {
-    "desCap"       : 2000, // mAh
-    "senseRes"     : 0.01, // ohms
-    "chrgTerm"     : 20,   // mA
-    "emptyVTarget" : 3.3,  // V
-    "recoveryV"    : 3.88, // V
-    "chrgV"        : MAX17055_V_CHRG_4_4_OR_4_35,
-    "battType"     : MAX17055_BATT_TYPE.LiCoO2
+  "desCap"       : 2000, // mAh
+  "senseRes"     : 0.01, // ohms
+  "chrgTerm"     : 20,   // mA
+  "emptyVTarget" : 3.3,  // V
+  "recoveryV"    : 3.88, // V
+  "chrgV"        : MAX17055_V_CHRG_4_4_OR_4_35,
+  "battType"     : MAX17055_BATT_TYPE.LiCoO2
 }
 
 fuelGauge.init(settings, function(err) {
-    if (err != null) {
-        server.error(err);
-    } else {
-        server.log("Fuel gauge initialized.");
-        // Start using fuel gauge.
-    }
+  if (err != null) {
+    server.error(err);
+  } else {
+    server.log("Fuel gauge initialized.");
+    // Start using fuel gauge.
+  }
 });
 ```
 
 ### getStateOfCharge() ###
 
-Returns the reported remaining capacity in mAh and state-of-charge percentage output. The reported capacity is protected from making sudden jumps during load changes.
-
-#### Parameters ####
-
-None.
+This method returns the gauge's reported remaining capacity in mAh and state-of-charge percentage output. The reported capacity is protected from making sudden jumps during load changes.
 
 #### Return Value ####
 
-Table — with keys "percent" and "capacity" returned in mAh.
+Table &mdash; Contains the keys *percent* and *capacity*, each with values in mAh.
 
 #### Example ####
 
@@ -104,72 +99,60 @@ server.log("Percent of battery remaining: " + state.percent + "%");
 
 ### getTimeTilEmpty() ###
 
-Returns the estimated time to empty (TTE) for the application under present temperature and load conditions. The TTE value is determined by relating average capacity with avgerage current. The corresponding avgerage current filtering gives a delay in TTE, but provides more stable results. **Note:** This may take a few charge cycles before it returns a non-default value.
+This method returns the estimated time to empty (TTE) for the battery under present temperature and load conditions. The TTE value is determined by relating the average capacity to the average current. The corresponding average current filtering gives a delay in TTE, but provides more stable results.
 
-#### Parameters ####
-
-None.
+**Note** The battery may require a few charge cycles to pass before this call returns a non-default value.
 
 #### Return Value ####
 
-Float — The estimated time in hours until battery is empty.
+Float &mdash; The estimated time in hours until the battery is empty.
 
 #### Example ####
 
 ```squirrel
 local tte = fuelGauge.getTimeTilEmpty();
-server.log("Time til empty: " + tte + "h");
+server.log("Time til empty: " + tte + " hours");
 ```
 
 ### getTimeTilFull() ###
 
-Returns the estimated time to full (TTF) for the application under present conditions. The TTF value is determined by learning the constant current and constant voltage portions of the charge cycle based on experience of prior charge cycles. Time to full is then estimated by comparing present charge current to the charge termination current. Operation of the TTF register assumes all charge profiles are consistent in the application. **Note:** This may take a few charge cycles before it returns a non-default value.
+This method returns the estimated time to full (TTF) for the battery under present conditions. The TTF value is determined by determining the constant current and constant voltage portions of the charge cycle based on experience of prior charge cycles. Time to full is then estimated by comparing present charge current to the charge termination current. Operation of the TTF register assumes all charge profiles are consistent in the application. 
 
-#### Parameters ####
-
-None.
+**Note** The battery may require a few charge cycles to pass before this call returns a non-default value.
 
 #### Return Value ####
 
-Float — The estimated time in hours until battery is fully charged.
+Float &mdash; The estimated time in hours until the battery is fully charged.
 
 #### Example ####
 
 ```squirrel
 local ttf = fuelGauge.getTimeTilFull();
-server.log("Time til full: " + ttf + "h");
+server.log("Time til full: " + ttf + " hours");
 ```
 
 ### getVoltage() ###
 
-Returns the voltage measured between BATT and CSP pins.
-
-#### Parameters ####
-
-None.
+This method returns the voltage measured between BATT and CSP pins.
 
 #### Return Value ####
 
-Float — The voltage in volts.
+Float &mdash; A voltage in V.
 
 #### Example ####
 
 ```squirrel
-local votage = fuelGauge.getVoltage();
-server.log("Voltage: " + votage + "V");
+local voltage = fuelGauge.getVoltage();
+server.log("BATT-to-CASP voltage: " + voltage + "V");
 ```
 
 ### getCurrent() ###
 
-This method measures the voltage between the CSP and CSN pins. Voltages outside the minimum and maximum register values are reported as the minimum or maximum value. The measured voltage value is divided by the sense resistance and converted to Amperes. The value of the sense resistor determines the resolution and the fullscale range of the current readings.
-
-#### Parameters ####
-
-None.
+This method measures the voltage between the CSP and CSN pins. Voltages outside the minimum and maximum register values are reported as the minimum or maximum value. The measured voltage value is then divided by the sense resistance and converted to mA. The value of the sense resistor determines the resolution and the full scale range of the current readings.
 
 #### Return Value ####
 
-Float — The current in mA.
+Float &mdash; A current in mA.
 
 #### Example ####
 
@@ -180,15 +163,11 @@ server.log("Current: " + current + "mA");
 
 ### getAvgCurrent() ###
 
-Returns an average of current readings in mA.
-
-#### Parameters ####
-
-None.
+This method returns an average of current readings in mA.
 
 #### Return Value ####
 
-Float — An average of current readings in mA.
+Float &mdash; A current in mA.
 
 #### Example ####
 
@@ -199,15 +178,11 @@ server.log("Average current: " + current + "mA");
 
 ### getAvgCapacity() ###
 
-Returns the calculated available capacity of the battery based on all inputs from the ModelGauge m5 algorithm including empty compensation. This provides unfiltered results. Jumps in the reported values can be caused by abrupt changes in load current or temperature.
-
-#### Parameters ####
-
-None.
+This method returns the calculated available capacity of the battery based on all inputs from the ModelGauge m5 algorithm, including empty compensation. This provides unfiltered results. Jumps in the reported values can be caused by abrupt changes in load current or temperature.
 
 #### Return Value ####
 
-Float — Unfiltered capacity results in mAh.
+Float &mdash; A capacity result in mAh.
 
 #### Example ####
 
@@ -218,15 +193,11 @@ server.log("Cell capacity: " + capacity + "mAh");
 
 ### getTemperature() ###
 
-Returns the internal die temperature in °C.
-
-#### Parameters ####
-
-None.
+Returns the internal die temperature in degrees Celsius.
 
 #### Return Value ####
 
-Float — The temperature in °C.
+Float &mdash; A temperature in &deg;C.
 
 #### Example ####
 
@@ -235,81 +206,72 @@ local temp = fuelGauge.getTemperature();
 server.log("Temp: " + temp + "°C");
 ```
 
-### enableAlerts(alerts) ###
+### enableAlerts(*alerts*) ###
 
-Use this method to enable or disable the alert pin, battery or percent change alerts.
+Use this method to enable or disable the alert pin, battery or percentage change alerts.
 
 #### Parameters ####
 
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
-| *alerts* | table | Yes | A table with the alerts to be enabled/disabled. See below. |
+| *alerts* | Table | Yes | A table with the alerts to be enabled/disabled *(see below)* |
 
-##### Enable Alerts Table #####
+#### Enable Alerts ####
 
-| Slot Name | Type | Required | Description |
+| Key | Type | Required | Description |
 | --- | --- | --- | --- |
-| *enAlertPin* | boolean | No | Whether to enable or disable the alert interrupt pin. |
-| *enBattRemove* | boolean | No | Whether to enable or disable an alert when battery is removed. |
-| *enBattInsert* | boolean | No | Whether to enable or disable an alert when battery is inserted. |
-| *enChargeStatePercentChange* | boolean | No | Whether to enable or disable an alert when state of charge percentage crosses an integer percentage boundary, such as 50.0%, 51.0%, etc. |
+| *enAlertPin* | Boolean | No | Enable or disable the alert interrupt pin |
+| *enBattRemove* | Boolean | No | Enable or disable an alert when a battery is removed |
+| *enBattInsert* | Boolean | No | Enable or disable an alert when a battery is inserted |
+| *enChargeStatePercentChange* | Boolean | No | Enable or disable an alert when the charge percentage crosses an integer percentage boundary, such as 50.0%, 51.0%, etc |
 
 #### Return Value ####
 
-None.
+Nothing.
 
 #### Example ####
 
 ```squirrel
 local enAlerts = {
-    "enChargeStatePercentChange" : false,
-    "enBattInsert" : true
+  "enChargeStatePercentChange" : false,
+  "enBattInsert" : true
 };
+
 fuelGauge.enableAlerts(enAlerts);
 ```
 
 ### getAlertStatus() ###
 
-Returns a table with the current status of all flags related to alerts. Alerts need to be reset by calling *clearStatusAlerts()*.
-
-#### Parameters ####
-
-None.
+This method returns a table containing the current status of all flags related to alerts. Alerts need to be reset by calling *clearStatusAlerts()*.
 
 #### Return Value ####
 
-Table — with boolean alert thresholds and battery insertion or removal flags.
+Table &mdash; Contains the following keys:
 
-##### Return Table #####
-
-| Slot Name | Type | Description |
+| Key | Type | Description |
 | --- | --- | --- |
-| *powerOnReset* | boolean | True when device detects a software or hardware power on reset event has occurred. |
-| *battRemovalDetected* | boolean | When enabled, true when the system detects that a battery has been removed. This flag must be cleared in order to detect the next removal event. |
-| *battInsertDetected* | boolean | When enabled, true when the system detects that a battery has been inserted. This flag must be cleared in order to detect the next insertion event. |
-| *battAbsent* | boolean | True when the system detects that a battery is absent, false when system detects battery is present. |
-| *chargeStatePercentChange* | boolean | When enabled, true whenever the state of charge percentage crosses an integer percentage boundary, such as 50.0%, 51.0%, etc. This flag must be cleared to detect next event. |
+| *powerOnReset* | Boolean | `true` when the system detects that a software or hardware power on reset event has occurred |
+| *battRemovalDetected* | Boolean | When detection is enabled, this is `true` when the system detects that a battery has been removed. This flag must be cleared in order to detect the next removal event |
+| *battInsertDetected* | Boolean | When detection is enabled, this is `true` when the system detects that a battery has been inserted. This flag must be cleared in order to detect the next insertion event |
+| *battAbsent* | Boolean | `true` when the system detects that a battery is absent; `false` when system detects that a battery is present |
+| *chargeStatePercentChange* | Boolean | When detection is enabled, this is `true` whenever the charge percentage crosses an integer percentage boundary, such as 50.0%, 51.0%, etc. This flag must be cleared to detect next event |
 
 #### Example ####
 
 ```squirrel
 local status = fuelGauge.getAlertStatus();
 foreach (alert, state in status) {
-    if (state) server.log("Alert detected: " + alert);
+  if (state) server.log("Alert detected: " + alert);
 }
 ```
 
 ### clearStatusAlerts() ###
 
-Clears all the status alerts flags, so next event can be detected.
-
-#### Parameters ####
-
-None.
+This method clears all of the status alerts flags, so that the next event can be detected.
 
 #### Return Value ####
 
-None.
+Nothing.
 
 #### Example ####
 
@@ -317,25 +279,22 @@ None.
 local status = fuelGauge.getAlertStatus();
 local alertDetected = false;
 foreach (alert, state in status) {
-    if (state) {
-        alertDetected = true;
-        server.log("Alert detected: " + alert);
-    }
+  if (state) {
+    alertDetected = true;
+    server.log("Alert detected: " + alert);
+  }
 }
+
 if (alertDetected) fuelGauge.clearStatusAlerts();
 ```
 
 ### getDeviceRev() ###
 
-Returns revision information. The initail silicon revision is `0x4010`.
-
-#### Parameters ####
-
-None.
+This method returns the device revision information. The initial silicon revision is `0x4010`.
 
 #### Return Value ####
 
-Integer - Revision information.
+Integer &mdash; A revision number.
 
 #### Example ####
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This method initializes the fuel gauge. If a power on reset alert is detected, t
 | Parameter | Type | Required | Description |
 | --- | --- | --- | --- |
 | *settings* | Table | Yes | A table of configuration settings *(see below)* |
-| *callback* | Function | No | A function that will be triggered when initialization is complete. It has one (required) parameter of its own which will receive an error message string if an error was encountered during initializion, otherwise `null` |
+| *callback* | Function | No | A function that will be triggered when initialization is complete. It has one (required) parameter of its own which will receive an error message string if an error was encountered during initialization, otherwise `null` |
 
 #### Settings Table Options ####
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The MAX17055 is a low-power fuel-gauge IC that implements the [Maxim ModelGauge m5 EZ algorithm](https://www.maximintegrated.com/en/design/partners-and-technology/design-technology/modelgauge-battery-fuel-gauge-technology.html). It measures battery voltage, current and temperature to produce fuel gauge results. Its typical power consumption is 7μA.
 
-**To add this library to your project, add** `#require "MAX17055.device.lib.nut:1.0.0"` **to the top of your device code.**
+**To add this library to your project, add** `#require "MAX17055.device.lib.nut:1.0.1"` **to the top of your device code.**
 
 ## Class Usage ##
 
@@ -22,7 +22,7 @@ Nothing.
 #### Example ####
 
 ```squirrel
-#require "MAX17055.device.lib.nut:1.0.0"
+#require "MAX17055.device.lib.nut:1.0.1"
 
 local i2c = hardware.i2cKL;
 i2c.configure(CLOCK_SPEED_400_KHZ);
@@ -67,7 +67,7 @@ local settings = {
   "chrgTerm"     : 20,   // mA
   "emptyVTarget" : 3.3,  // V
   "recoveryV"    : 3.88, // V
-  "chrgV"        : MAX17055_V_CHRG_4_4_OR_4_35,
+  "chrgV"        : MAX17055_V_CHRG_4_2,
   "battType"     : MAX17055_BATT_TYPE.LiCoO2
 }
 
@@ -232,6 +232,7 @@ Nothing.
 #### Example ####
 
 ```squirrel
+// Enable alert when battery is inserted, disable percent change alert
 local enAlerts = {
   "enChargeStatePercentChange" : false,
   "enBattInsert" : true

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The MAX17055 is a low power 7μA operating current fuel gauge IC that implements
 
 **To add this library to your project, add the following to the top of your device code:**
 
-`#require "MAX170555.lib.nut:1.0.0"`
+`#require "MAX170555.lib.nut:1.0.1"`
 
 ## Class Usage ##
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,7 @@ The MAX17055 is a low power fuel gauge IC that implements Maxim ModelGauge m5 EZ
 
 **To add this library to your project, add the following to the top of your device code:**
 
-<<<<<<< HEAD
-`#require "MAX170555.lib.nut:1.0.1"`
-=======
-`#require "MAX17055.device.lib.nut:1.0.0"`
->>>>>>> e06a46af4b66678eeefe729b264fa3276ab28fda
+`#require "MAX17055.device.lib.nut:1.0.1"`
 
 ## Class Usage ##
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MAX17055 #
 
-The MAX17055 is a low-power fuel-gauge IC that implements the [Maxim ModelGauge m5 EZ algorithm](https://www.maximintegrated.com/en/design/partners-and-technology/design-technology/modelgauge-battery-fuel-gauge-technology.html). It measures battery voltage, current and temperature to produce fuel gauge results. Its typical power consumption is 7μA.
+The [MAX17055](https://datasheets.maximintegrated.com/en/ds/MAX17055.pdf) is a low-power fuel-gauge IC that implements the [Maxim ModelGauge m5 EZ algorithm](https://www.maximintegrated.com/en/design/partners-and-technology/design-technology/modelgauge-battery-fuel-gauge-technology.html). It measures battery voltage, current and temperature to produce fuel gauge results. Its typical power consumption is 7μA.
 
 **To add this library to your project, add** `#require "MAX17055.device.lib.nut:1.0.1"` **to the top of your device code.**
 
@@ -116,7 +116,7 @@ server.log("Time til empty: " + tte + " hours");
 
 ### getTimeTilFull() ###
 
-This method returns the estimated time to full (TTF) for the battery under present conditions. The TTF value is determined by determining the constant current and constant voltage portions of the charge cycle based on experience of prior charge cycles. Time to full is then estimated by comparing present charge current to the charge termination current. Operation of the TTF register assumes all charge profiles are consistent in the application. 
+This method returns the estimated time to full (TTF) for the battery under present conditions. The TTF value is determined by determining the constant current and constant voltage portions of the charge cycle based on experience of prior charge cycles. Time to full is then estimated by comparing present charge current to the charge termination current. Operation of the TTF register assumes all charge profiles are consistent in the application.
 
 **Note** The battery may require a few charge cycles to pass before this call returns a non-default value.
 

--- a/example/fuelGaugeExample.device.nut
+++ b/example/fuelGaugeExample.device.nut
@@ -16,7 +16,7 @@ settings <- {
     "chrgTerm"     : 20,   // mA
     "emptyVTarget" : 3.3,  // V
     "recoveryV"    : 3.88, // V
-    "chrgV"        : MAX17055_V_CHRG_4_4_OR_4_35,
+    "chrgV"        : MAX17055_V_CHRG_4_2,
     "battType"     : MAX17055_BATT_TYPE.LiCoO2
 }
 

--- a/example/fuelGaugeExample.device.nut
+++ b/example/fuelGaugeExample.device.nut
@@ -1,4 +1,4 @@
-#require "MAX17055.device.lib.nut:1.0.0"
+#require "MAX17055.device.lib.nut:1.0.1"
 
 server.log("Device running....")
 server.log("---------------------");


### PR DESCRIPTION
bug fix - calculating capacity
bug fix - refresh bit mask
bug fix - scope issue in _verify method
fixed typo in register name variable
updated example to use 4.2V charge (more common battery)
simplified 2s complement calculation
updated state of charge percentage to float