### PR TITLE
v1.0.2

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/.impt.test
+++ b/.impt.test
@@ -1,0 +1,12 @@
+{
+  "deviceGroupId": "c81c78b0-c569-bf90-3ff5-28dfb745e7fd",
+  "timeout": 180,
+  "stopOnFail": false,
+  "allowDisconnect": false,
+  "builderCache": false,
+  "deviceFile": "MAX17055.device.lib.nut",
+  "testFiles": [
+    "*.test.nut",
+    "tests/**/*.test.nut"
+  ]
+}

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright 2018 Electric Imp
+Copyright 2018-19 Electric Imp
 
 SPDX-License-Identifier: MIT
 

--- a/MAX17055.device.lib.nut
+++ b/MAX17055.device.lib.nut
@@ -1,6 +1,6 @@
 // MIT License
 //
-// Copyright 2018 Electric Imp
+// Copyright 2018-19 Electric Imp
 //
 // SPDX-License-Identifier: MIT
 //
@@ -88,7 +88,7 @@ class MAX17055 {
     constructor(i2c, addr = null) {
         _i2c = i2c;
         _addr = (addr == null) ? MAX17055_DEFAULT_I2C_ADDR : addr;
-        
+
         _regReadyCounter    = 0;
         _writeVerifyCounter = 0;
     }
@@ -270,11 +270,11 @@ class MAX17055 {
     function getAlertStatus() {
         // NOTE: Only supported alerts are exposed in table
         // with readable keys, however the raw value is also
-        // included for debugging purposes. 
+        // included for debugging purposes.
         local status = _readReg(MAX17055_STATUS_REG);
         return {
             "powerOnReset"              : (status & 0x0002),
-            "chargeStatePercentChange"  : (status & 0x0080), 
+            "chargeStatePercentChange"  : (status & 0x0080),
             "raw"                       : status
         };
     }
@@ -286,9 +286,9 @@ class MAX17055 {
     function enableAlerts(alerts) {
         local config  = _readReg(MAX17055_CONFIG_REG);
         local config2 = _readReg(MAX17055_CONFIG_2_REG);
-        // NOTE: AIN Pin is not connected on impC001 or imp006 breakout 
+        // NOTE: AIN Pin is not connected on impC001 or imp006 breakout
         // boards, so battery insert and removal alerts cannot be
-        // detected on this hardware. Since we cannot test, these 
+        // detected on this hardware. Since we cannot test, these
         // are not currently supported by this library.
         if ("enAlertPin" in alerts) {
             // Config bit 2

--- a/MAX17055.device.lib.nut
+++ b/MAX17055.device.lib.nut
@@ -80,10 +80,9 @@ class MAX17055 {
     _i2c  = null;
     _addr = null;
 
-    _capacityLSB = null;
-    _currLSB = null;
-
-    _regReadyCounter = 0;
+    _capacityLSB        = null;
+    _currLSB            = null;
+    _regReadyCounter    = 0;
     _writeVerifyCounter = 0;
 
     constructor(i2c, addr = null) {
@@ -291,17 +290,17 @@ class MAX17055 {
         if ("enBattInsert" in alerts) {
             // Config bit 1
             local bit = 1;
-            config = (alerts.enBattRemove) ? (config | (0x01 << bit)) : (config & ~(0x01 << bit));
+            config = (alerts.enBattInsert) ? (config | (0x01 << bit)) : (config & ~(0x01 << bit));
         }
         if ("enAlertPin" in alerts) {
             // Config bit 2
             local bit = 2;
-            config = (alerts.enBattRemove) ? (config | (0x01 << bit)) : (config & ~(0x01 << bit));
+            config = (alerts.enAlertPin) ? (config | (0x01 << bit)) : (config & ~(0x01 << bit));
         }
         if ("enChargeStatePercentChange" in alerts) {
             // Config2 bit 7
             local bit = 7
-            config2 = (alerts.enBattRemove) ? (config2 | (0x01 << bit)) : (config2 & ~(0x01 << bit));
+            config2 = (alerts.enChargeStatePercentChange) ? (config2 | (0x01 << bit)) : (config2 & ~(0x01 << bit));
         }
         _writeReg(MAX17055_CONFIG_REG, config);
         _writeReg(MAX17055_CONFIG_2_REG, config2);

--- a/MAX17055.device.lib.nut
+++ b/MAX17055.device.lib.nut
@@ -268,13 +268,14 @@ class MAX17055 {
     }
 
     function getAlertStatus() {
+        // NOTE: Only supported alerts are exposed in table
+        // with readable keys, however the raw value is also
+        // included for debugging purposes. 
         local status = _readReg(MAX17055_STATUS_REG);
         return {
             "powerOnReset"              : (status & 0x0002),
-            "battRemovalDetected"       : (status & 0x8000),
-            "battInsertDetected"        : (status & 0x0800),
-            "battAbsent"                : (status & 0x0008),
-            "chargeStatePercentChange"  : (status & 0x0080)
+            "chargeStatePercentChange"  : (status & 0x0080), 
+            "raw"                       : status
         };
     }
 
@@ -285,16 +286,10 @@ class MAX17055 {
     function enableAlerts(alerts) {
         local config  = _readReg(MAX17055_CONFIG_REG);
         local config2 = _readReg(MAX17055_CONFIG_2_REG);
-        if ("enBattRemove" in alerts) {
-            // Config bit 0
-            local bit = 0;
-            config = (alerts.enBattRemove) ? (config | (0x01 << bit)) : (config & ~(0x01 << bit));
-        }
-        if ("enBattInsert" in alerts) {
-            // Config bit 1
-            local bit = 1;
-            config = (alerts.enBattInsert) ? (config | (0x01 << bit)) : (config & ~(0x01 << bit));
-        }
+        // NOTE: AIN Pin is not connected on impC001 or imp006 breakout 
+        // boards, so battery insert and removal alerts cannot be
+        // detected on this hardware. Since we cannot test, these 
+        // are not currently supported by this library.
         if ("enAlertPin" in alerts) {
             // Config bit 2
             local bit = 2;

--- a/MAX17055.device.lib.nut
+++ b/MAX17055.device.lib.nut
@@ -345,7 +345,8 @@ class MAX17055 {
                 }.bindenv(this))
             } else {
                 _regReadyCounter = 0;
-                next(format("Error reading reg: 0x%02X Err: %i", reg, _i2c.readerror()));
+                local err = (val == null) ? format("Err: %i", _i2c.readerror()) : "Err: reg bit not ready.";
+                next(format("Error reading reg: 0x%02X %s", reg, err));
             }
         }
     }

--- a/MAX17055.device.lib.nut
+++ b/MAX17055.device.lib.nut
@@ -75,19 +75,22 @@ enum MAX17055_BATT_TYPE {
 
 class MAX17055 {
 
-    static VERSION = "1.0.1";
+    static VERSION = "1.0.2";
 
     _i2c  = null;
     _addr = null;
 
     _capacityLSB        = null;
     _currLSB            = null;
-    _regReadyCounter    = 0;
-    _writeVerifyCounter = 0;
+    _regReadyCounter    = null;
+    _writeVerifyCounter = null;
 
     constructor(i2c, addr = null) {
         _i2c = i2c;
         _addr = (addr == null) ? MAX17055_DEFAULT_I2C_ADDR : addr;
+        
+        _regReadyCounter    = 0;
+        _writeVerifyCounter = 0;
     }
 
     // Currently only supports (EZ config not INI file, all calculations taken from software implementaion guide)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The [MAX17055](https://datasheets.maximintegrated.com/en/ds/MAX17055.pdf) is a low-power fuel-gauge IC that implements the [Maxim ModelGauge m5 EZ algorithm](https://www.maximintegrated.com/en/design/partners-and-technology/design-technology/modelgauge-battery-fuel-gauge-technology.html). It measures battery voltage, current and temperature to produce fuel gauge results. Its typical power consumption is 7μA.
 
-**To add this library to your project, add** `#require "MAX17055.device.lib.nut:1.0.2"` **to the top of your device code.**
+**To include this library in your project, add** `#require "MAX17055.device.lib.nut:1.0.2"` **at the top of your device code.**
 
 ## Class Usage ##
 
@@ -10,10 +10,10 @@ The [MAX17055](https://datasheets.maximintegrated.com/en/ds/MAX17055.pdf) is a l
 
 #### Parameters ####
 
-| Parameter | Type | Required | Description |
+| Parameter | Type | Required? | Description |
 | --- | --- | --- | --- |
-| *i2cBus* | imp i2c bus object | Yes | The imp i2c bus that the fuel gauge is connected to. The i2c bus **must** be preconfigured; the library will not configure the bus |
-| *i2cAddress* | Integer | No | The i2c address of the fuel gauge. Default: `0x6C` |
+| *i2cBus* | Object | Yes | The imp I&sup2;C bus that the fuel gauge is connected to. The bus **must** be pre-configured; the library will not configure the bus |
+| *i2cAddress* | Integer | No | The I&sup2;C address of the fuel gauge. Default: `0x6C` |
 
 #### Return Value ####
 
@@ -37,18 +37,18 @@ This method initializes the fuel gauge. If a power on reset alert is detected, t
 
 #### Parameters ####
 
-| Parameter | Type | Required | Description |
+| Parameter | Type | Required? | Description |
 | --- | --- | --- | --- |
 | *settings* | Table | Yes | A table of configuration settings *(see below)* |
 | *callback* | Function | No | A function that will be triggered when initialization is complete. It has one (required) parameter of its own which will receive an error message string if an error was encountered during initialization, otherwise `null` |
 
 #### Settings Table Options ####
 
-| Key | Type | Required | Description |
+| Key | Type | Required? | Description |
 | --- | --- | --- | --- |
 | *desCap* | Integer | Yes | The designed capacity of the battery in mAh |
 | *senseRes* | Float | Yes | The size of the sense resistor in &Omega; |
-| *chrgTerm* | Integer | Yes | The battery's termination charge in mA |
+| *chrgTerm* | Integer | Yes | The battery’s termination charge in mA |
 | *emptyVTarget* | Float | Yes | The empty target voltage in V. Resolution is 10mV |
 | *recoveryV* | Float | Yes | A recovery voltage in V. Once the cell voltage rises above this point, empty voltage detection is re-enabled. Resolution is 40mV |
 | *chrgV* | Integer | Yes | The charge voltage. Use the class constants *MAX17055_V_CHRG_4_2* (4.2V) or *MAX17055_V_CHRG_4_4_OR_4_35* (4.35V or 4.4V) |
@@ -62,28 +62,28 @@ Nothing.
 
 ```squirrel
 local settings = {
-  "desCap"       : 2000, // mAh
-  "senseRes"     : 0.01, // ohms
-  "chrgTerm"     : 20,   // mA
-  "emptyVTarget" : 3.3,  // V
-  "recoveryV"    : 3.88, // V
-  "chrgV"        : MAX17055_V_CHRG_4_2,
-  "battType"     : MAX17055_BATT_TYPE.LiCoO2
+    "desCap"       : 2000, // mAh
+    "senseRes"     : 0.01, // ohms
+    "chrgTerm"     : 20,   // mA
+    "emptyVTarget" : 3.3,  // V
+    "recoveryV"    : 3.88, // V
+    "chrgV"        : MAX17055_V_CHRG_4_2,
+    "battType"     : MAX17055_BATT_TYPE.LiCoO2
 }
 
 fuelGauge.init(settings, function(err) {
-  if (err != null) {
-    server.error(err);
-  } else {
-    server.log("Fuel gauge initialized.");
-    // Start using fuel gauge.
-  }
+    if (err != null) {
+        server.error(err);
+    } else {
+        server.log("Fuel gauge initialized.");
+        // Start using fuel gauge.
+    }
 });
 ```
 
 ### getStateOfCharge() ###
 
-This method returns the gauge's reported remaining capacity in mAh and state-of-charge percentage output. The reported capacity is protected from making sudden jumps during load changes.
+This method returns the gauge’s reported remaining capacity in mAh and state-of-charge percentage output. The reported capacity is protected from making sudden jumps during load changes.
 
 #### Return Value ####
 
@@ -212,16 +212,16 @@ Use this method to enable or disable the alert pin, battery or percentage change
 
 #### Parameters ####
 
-| Parameter | Type | Required | Description |
+| Parameter | Type | Required? | Description |
 | --- | --- | --- | --- |
 | *alerts* | Table | Yes | A table with the alerts to be enabled/disabled *(see below)* |
 
 #### Enable Alerts ####
 
-| Key | Type | Required | Description |
+| Key | Type | Required? | Description |
 | --- | --- | --- | --- |
 | *enChargeStatePercentChange* | Boolean | No | Enable or disable an alert when the charge percentage crosses an integer percentage boundary, such as 50.0%, 51.0%, etc |
-| *enAlertPin* | Boolean | No | Enable or disable the alert interrupt pin. NOTE: This pin is not connected on impC001 breakout board, but can be connected via Test Piont 4 (TP4) |
+| *enAlertPin* | Boolean | No | Enable or disable the alert interrupt pin. **Note** This pin is not connected on the impC001 breakout board, but can be connected via Test Point 4 (TP4) |
 
 #### Return Value ####
 
@@ -232,8 +232,8 @@ Nothing.
 ```squirrel
 // Enable alert when battery is inserted, disable percent change alert
 local enAlerts = {
-  "enChargeStatePercentChange" : false,
-  "enBattInsert" : true
+    "enChargeStatePercentChange" : false,
+    "enBattInsert" : true
 };
 
 fuelGauge.enableAlerts(enAlerts);
@@ -241,7 +241,7 @@ fuelGauge.enableAlerts(enAlerts);
 
 ### getAlertStatus() ###
 
-This method returns a table containing the current status of flags related to alerts. Alerts need to be reset by calling *clearStatusAlerts()*.
+This method returns a table containing the current status of flags related to alerts. Alerts need to be reset by calling [*clearStatusAlerts()*](#clearstatusalerts).
 
 #### Return Value ####
 
@@ -251,14 +251,14 @@ Table &mdash; Contains the following keys:
 | --- | --- | --- |
 | *powerOnReset* | Boolean | `true` when the system detects that a software or hardware power on reset event has occurred |
 | *chargeStatePercentChange* | Boolean | When detection is enabled, this is `true` whenever the charge percentage crosses an integer percentage boundary, such as 50.0%, 51.0%, etc. This flag must be cleared to detect next event |
-| *raw* | Integer | Raw status register value for debugging purposes | 
+| *raw* | Integer | Raw status register value for debugging purposes |
 
 #### Example ####
 
 ```squirrel
 local status = fuelGauge.getAlertStatus();
 foreach (alert, state in status) {
-  if (state && alert != "raw") server.log("Alert detected: " + alert);
+    if (state && alert != "raw") server.log("Alert detected: " + alert);
 }
 ```
 
@@ -276,10 +276,10 @@ Nothing.
 local status = fuelGauge.getAlertStatus();
 local alertDetected = false;
 foreach (alert, state in status) {
-  if (state) {
-    alertDetected = true;
-    server.log("Alert detected: " + alert);
-  }
+    if (state) {
+        alertDetected = true;
+        server.log("Alert detected: " + alert);
+    }
 }
 
 if (alertDetected) fuelGauge.clearStatusAlerts();

--- a/README.md
+++ b/README.md
@@ -251,14 +251,14 @@ Table &mdash; Contains the following keys:
 | --- | --- | --- |
 | *powerOnReset* | Boolean | `true` when the system detects that a software or hardware power on reset event has occurred |
 | *chargeStatePercentChange* | Boolean | When detection is enabled, this is `true` whenever the charge percentage crosses an integer percentage boundary, such as 50.0%, 51.0%, etc. This flag must be cleared to detect next event |
-| *raw* | Integer | Raw status register value. For debugging purposes | 
+| *raw* | Integer | Raw status register value for debugging purposes | 
 
 #### Example ####
 
 ```squirrel
 local status = fuelGauge.getAlertStatus();
 foreach (alert, state in status) {
-  if (state && alert !== "raw") server.log("Alert detected: " + alert);
+  if (state && alert != "raw") server.log("Alert detected: " + alert);
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The [MAX17055](https://datasheets.maximintegrated.com/en/ds/MAX17055.pdf) is a low-power fuel-gauge IC that implements the [Maxim ModelGauge m5 EZ algorithm](https://www.maximintegrated.com/en/design/partners-and-technology/design-technology/modelgauge-battery-fuel-gauge-technology.html). It measures battery voltage, current and temperature to produce fuel gauge results. Its typical power consumption is 7μA.
 
-**To add this library to your project, add** `#require "MAX17055.device.lib.nut:1.0.1"` **to the top of your device code.**
+**To add this library to your project, add** `#require "MAX17055.device.lib.nut:1.0.2"` **to the top of your device code.**
 
 ## Class Usage ##
 
@@ -22,7 +22,7 @@ Nothing.
 #### Example ####
 
 ```squirrel
-#require "MAX17055.device.lib.nut:1.0.1"
+#require "MAX17055.device.lib.nut:1.0.2"
 
 local i2c = hardware.i2cKL;
 i2c.configure(CLOCK_SPEED_400_KHZ);

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# MAX17055 #
+# MAX17055 1.0.2 #
 
 The [MAX17055](https://datasheets.maximintegrated.com/en/ds/MAX17055.pdf) is a low-power fuel-gauge IC that implements the [Maxim ModelGauge m5 EZ algorithm](https://www.maximintegrated.com/en/design/partners-and-technology/design-technology/modelgauge-battery-fuel-gauge-technology.html). It measures battery voltage, current and temperature to produce fuel gauge results. Its typical power consumption is 7μA.
 

--- a/README.md
+++ b/README.md
@@ -220,10 +220,8 @@ Use this method to enable or disable the alert pin, battery or percentage change
 
 | Key | Type | Required | Description |
 | --- | --- | --- | --- |
-| *enAlertPin* | Boolean | No | Enable or disable the alert interrupt pin |
-| *enBattRemove* | Boolean | No | Enable or disable an alert when a battery is removed |
-| *enBattInsert* | Boolean | No | Enable or disable an alert when a battery is inserted |
 | *enChargeStatePercentChange* | Boolean | No | Enable or disable an alert when the charge percentage crosses an integer percentage boundary, such as 50.0%, 51.0%, etc |
+| *enAlertPin* | Boolean | No | Enable or disable the alert interrupt pin. NOTE: This pin is not connected on impC001 breakout board, but can be connected via Test Piont 4 (TP4) |
 
 #### Return Value ####
 
@@ -243,7 +241,7 @@ fuelGauge.enableAlerts(enAlerts);
 
 ### getAlertStatus() ###
 
-This method returns a table containing the current status of all flags related to alerts. Alerts need to be reset by calling *clearStatusAlerts()*.
+This method returns a table containing the current status of flags related to alerts. Alerts need to be reset by calling *clearStatusAlerts()*.
 
 #### Return Value ####
 
@@ -252,17 +250,15 @@ Table &mdash; Contains the following keys:
 | Key | Type | Description |
 | --- | --- | --- |
 | *powerOnReset* | Boolean | `true` when the system detects that a software or hardware power on reset event has occurred |
-| *battRemovalDetected* | Boolean | When detection is enabled, this is `true` when the system detects that a battery has been removed. This flag must be cleared in order to detect the next removal event |
-| *battInsertDetected* | Boolean | When detection is enabled, this is `true` when the system detects that a battery has been inserted. This flag must be cleared in order to detect the next insertion event |
-| *battAbsent* | Boolean | `true` when the system detects that a battery is absent; `false` when system detects that a battery is present |
 | *chargeStatePercentChange* | Boolean | When detection is enabled, this is `true` whenever the charge percentage crosses an integer percentage boundary, such as 50.0%, 51.0%, etc. This flag must be cleared to detect next event |
+| *raw* | Integer | Raw status register value. For debugging purposes | 
 
 #### Example ####
 
 ```squirrel
 local status = fuelGauge.getAlertStatus();
 foreach (alert, state in status) {
-  if (state) server.log("Alert detected: " + alert);
+  if (state && alert !== "raw") server.log("Alert detected: " + alert);
 }
 ```
 

--- a/example/fuelGaugeExample.device.nut
+++ b/example/fuelGaugeExample.device.nut
@@ -1,4 +1,4 @@
-#require "MAX17055.device.lib.nut:1.0.1"
+#require "MAX17055.device.lib.nut:1.0.2"
 
 server.log("Device running....")
 server.log("---------------------");

--- a/example/fuelGaugeExample.device.nut
+++ b/example/fuelGaugeExample.device.nut
@@ -30,8 +30,6 @@ settings <- {
 // Alert settings
 alerts <- {
     "enAlertPin"   : false,
-    "enBattRemove" : true,
-    "enBattInsert" : true,
     "enChargeStatePercentChange" : true
 }
 
@@ -40,7 +38,7 @@ function checkAlertStatus() {
     local status = fuelGauge.getAlertStatus();
     local alertDetected = false;
     foreach (alert, state in status) {
-        if (state) {
+        if (state && alert !== "raw") {
             alertDetected = true;
             server.log("Alert detected: " + alert);
         }

--- a/example/fuelGaugeExample.device.nut
+++ b/example/fuelGaugeExample.device.nut
@@ -1,3 +1,4 @@
+#require "BQ25895.device.lib.nut:3.0.0"
 #require "MAX17055.device.lib.nut:1.0.2"
 
 server.log("Device running....")
@@ -9,8 +10,11 @@ server.log(imp.getsoftwareversion());
 i2c <- hardware.i2cKL;
 i2c.configure(CLOCK_SPEED_400_KHZ);
 
-fuelGaugeReady <- false;
+// Initialize Libraries
+batteryCharger <- BQ25895(i2c);
 fuelGauge <- MAX17055(i2c);
+// Configure Battery Charger to default BQ25895 settings 4.208V, 2048mA.
+batteryCharger.enable();
 
 // Fuel gauge settings for a 2000mAh battery
 settings <- {
@@ -87,7 +91,6 @@ function initHandler(err) {
         server.log("Fuel gauge init error: " + err);
     } else {
         server.log("Fuel gauge initialized.");
-        fuelGaugeReady = true;
 
         // Enable/Disable alerts
         fuelGauge.enableAlerts(alerts);

--- a/example/fuelGaugeExample.device.nut
+++ b/example/fuelGaugeExample.device.nut
@@ -38,7 +38,7 @@ function checkAlertStatus() {
     local status = fuelGauge.getAlertStatus();
     local alertDetected = false;
     foreach (alert, state in status) {
-        if (state && alert !== "raw") {
+        if (state && alert != "raw") {
             alertDetected = true;
             server.log("Alert detected: " + alert);
         }

--- a/example/fuelGaugeExample.device.nut
+++ b/example/fuelGaugeExample.device.nut
@@ -1,9 +1,12 @@
 #require "MAX17055.device.lib.nut:1.0.2"
 
 server.log("Device running....")
-server.log("---------------------");
+server.log("----------------------------------------------------");
+imp.enableblinkup(true);
+server.log(imp.getsoftwareversion());
 
-i2c <- hardware.i2cXDC;
+// i2c for impC001 Breakout Board rev5.0
+i2c <- hardware.i2cKL;
 i2c.configure(CLOCK_SPEED_400_KHZ);
 
 fuelGaugeReady <- false;
@@ -24,7 +27,7 @@ settings <- {
 alerts <- {
     "enAlertPin"   : false,
     "enBattRemove" : true,
-    "enBattInsert" : false,
+    "enBattInsert" : true,
     "enChargeStatePercentChange" : true
 }
 
@@ -46,6 +49,8 @@ function checkAlertStatus() {
 }
 
 function logFuelGaugeInfo() {
+    server.log("Fuel gauge info:");
+    server.log("----------------------------------------------------");
     local state = fuelGauge.getStateOfCharge();
     server.log("Remaining cell capacity: " + state.capacity + "mAh");
     server.log("Percent of battery remaining: " + state.percent + "%");
@@ -65,6 +70,7 @@ function logFuelGaugeInfo() {
     server.log("Temp: " + temp + "°C");
     local rev = fuelGauge.getDeviceRev();
     server.log(format("Fuel gauge revision: 0x%04X", rev));
+    server.log("----------------------------------------------------");
 }
 
 function loop() {
@@ -73,7 +79,7 @@ function loop() {
     // Log current state of fuel gauge
     logFuelGaugeInfo();
     // Kick off next check
-    imp.wakeup(60, loop);
+    imp.wakeup(15, loop);
 }
 
 function initHandler(err) {

--- a/tests/Manual.device.test.nut
+++ b/tests/Manual.device.test.nut
@@ -32,8 +32,11 @@ class ManualTests extends ImpTestCase {
         _i2c = hardware.i2cKL;
         _i2c.configure(CLOCK_SPEED_400_KHZ);
         _fg = MAX17055(_i2c);
+        // initialize here (async blocking)
         return "Manual test setup complete.";
     }  
+
+    // test basics - voltage, current, temp, dev rev, soc
 
     function tearDown() {
         return "Manual tests finished.";

--- a/tests/Manual.device.test.nut
+++ b/tests/Manual.device.test.nut
@@ -52,7 +52,7 @@ class ManualTests extends ImpTestCase {
     
     function testGetVoltage() {
         local v = _fg.getVoltage();
-        assertBetween(v, 3.5, 4.2, "Voltage not in range: " + v + "V");
+        assertBetween(v, 3.5, 4.3, "Voltage not in range: " + v + "V");
 
         return "Get voltage test complete";
     }
@@ -86,7 +86,7 @@ class ManualTests extends ImpTestCase {
         assertTrue("capacity" in soc, "State of charge missing capacity key");
 
         // actual, from, to, msg
-        assertBetween(soc.capacity, 0, 2100, "SOC capacity not in range: " + soc.capacity + "mAh");
+        assertBetween(soc.capacity, 0, 3000, "SOC capacity not in range: " + soc.capacity + "mAh");
         assertBetween(soc.percent, 0, 120, "SOC percent not in range: " + soc.percent + "%");
 
         return "State or charge test complete";

--- a/tests/Manual.device.test.nut
+++ b/tests/Manual.device.test.nut
@@ -1,0 +1,42 @@
+// MIT License
+//
+// Copyright 2019 Electric Imp
+//
+// SPDX-License-Identifier: MIT
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+// EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+// OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+class ManualTests extends ImpTestCase {
+
+    _i2c = null;
+    _fg  = null;
+
+    function setUp() {
+        // impC001 breakout board rev5.0 
+        _i2c = hardware.i2cKL;
+        _i2c.configure(CLOCK_SPEED_400_KHZ);
+        _fg = MAX17055(_i2c);
+        return "Manual test setup complete.";
+    }  
+
+    function tearDown() {
+        return "Manual tests finished.";
+    }
+
+}

--- a/tests/StubbedI2C.device.nut
+++ b/tests/StubbedI2C.device.nut
@@ -1,0 +1,107 @@
+// MIT License
+//
+// Copyright 2019 Electric Imp
+//
+// SPDX-License-Identifier: MIT
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+// EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+// OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+class StubbedI2C {
+
+    _writeBuffer = null;
+    _readResp    = null;
+    _error       = null;
+    _enabled     = null;
+
+    constructor() {
+        _writeBuffer = {};
+        _readResp    = {};
+        _error       = 0;
+        _enabled     = false;
+    }
+
+    function configure(clockSpeed) {
+        _enabled = true;
+    }
+
+    function disable() {
+        _enabled = false;
+    }
+
+    function read(devAddr, regAddr, numBytes) {
+        if (!_enabled) {
+            _error = -13;   // NOT_ENABLED
+            return null;
+        }
+
+        if (devAddr in _readResp && regAddr in _readResp[devAddr]) {
+            local data = _readResp[devAddr][regAddr];
+            return data;
+        } else {
+            _error = "No data at device address register in read buffer.";
+        }
+
+        return null;
+    }
+
+    function readerror() {
+        // Store current error
+        local err = _error;
+        // Reset stored error to default 0: NO_ERROR
+        _error = 0;
+        // Return the current error
+        return err;
+    }
+
+    // Just accept write data, and return i2c error code
+    function write(devAddr, regPlusData) {
+        if (devAddr in _writeBuffer) {
+            local data = _writeBuffer[devAddr];
+            _writeBuffer[devAddr] = data + regPlusData;
+        } else {
+            _writeBuffer[devAddr] <- regPlusData;
+        }
+
+        // Return i2c error code 0: NO_ERROR, -13: NOT_ENABLED
+        return (_enabled) ? 0 : -13;
+    }
+
+    // Store read response in a table
+    function _setReadResp(devAddr, regAddr, data) {
+        if (devAddr in _readResp) {
+            _readResp[devAddr][regAddr] <- data;
+        } else {
+            _readResp[devAddr] <- {};
+            _readResp[devAddr][regAddr] <- data;
+        }
+    }
+
+    function _clearReadResp() {
+        _readResp = {};
+    }
+
+    function _getWriteBuffer(devAddr) {
+        return (devAddr in _writeBuffer) ? _writeBuffer[devAddr] : null;
+    }
+
+    function _clearWriteBuffer() {
+        _writeBuffer = {};
+    }
+
+}

--- a/tests/StubbedI2C.device.nut
+++ b/tests/StubbedI2C.device.nut
@@ -54,7 +54,8 @@ class StubbedI2C {
             local data = _readResp[devAddr][regAddr];
             return data;
         } else {
-            _error = "No data at device address register in read buffer.";
+            // Make up an integer that means "No data at device address register in read buffer."
+            _error = -100;
         }
 
         return null;

--- a/tests/StubbedI2C.device.test.nut
+++ b/tests/StubbedI2C.device.test.nut
@@ -33,6 +33,7 @@ class StubbedHardwareTests extends ImpTestCase {
         // Clear all buffers
         _i2c._clearWriteBuffer();
         _i2c._clearReadResp();
+        _i2c._clearWriteWatcher();
     }
 
     function setUp() {
@@ -52,10 +53,6 @@ class StubbedHardwareTests extends ImpTestCase {
         local _fg = MAX17055(_i2c, customAddr);
         assertEqual(customAddr, _fg._addr, "Non default i2c address did not match expected");
         return "Constructor optional params test complete.";
-    }
-
-    function tearDown() {
-        return "Stubbed hardware tests finished.";
     }
 
     function testInitBadParamsAsync() {
@@ -114,6 +111,7 @@ class StubbedHardwareTests extends ImpTestCase {
                 local expectedErr = format("Error reading reg: 0x%02X Err: %i", MAX17055_STATUS_REG, -100);
                 assertEqual(err, expectedErr, "Status bit i2c error in init did not create expected error");
 
+                _cleari2cBuffers();
                 return resolve("Init with status i2c error passed expected error to callback");
             }.bindenv(this))
         }.bindenv(this))
@@ -129,7 +127,7 @@ class StubbedHardwareTests extends ImpTestCase {
         // Don't set any read data for MAX17055_F_STAT_REG to cause error
         
         // Set readbuffer values
-        // MAX17055_V_CELL_REG to 0x0200 (lib always reads 2 bytes, and flips the bytes)
+        // MAX17055_STATUS_REG to 0x0200 (lib always reads 2 bytes, and flips the bytes)
         _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_STATUS_REG.tochar(), "\x02\x00");
 
         return Promise(function(resolve, reject) {
@@ -147,6 +145,7 @@ class StubbedHardwareTests extends ImpTestCase {
                 local expectedErr = format("Error reading reg: 0x%02X Err: %i", MAX17055_F_STAT_REG, -100);
                 assertEqual(err, expectedErr, "POR i2c error in init did not create expected error");
 
+                _cleari2cBuffers();
                 return resolve("Init with POR i2c error passed expected error to callback");
             }.bindenv(this))
         }.bindenv(this))
@@ -162,7 +161,7 @@ class StubbedHardwareTests extends ImpTestCase {
         // Set MAX17055_F_STAT_REG to not ready state to cause error
         
         // Set readbuffer values
-        // MAX17055_V_CELL_REG to 0x0200 (lib always reads 2 bytes, and flips the bytes)
+        // MAX17055_STATUS_REG to 0x0200 (lib always reads 2 bytes, and flips the bytes)
         _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_STATUS_REG.tochar(), "\x02\x00");
         // MAX17055_F_STAT_REG to 0xFFFF (lib always reads 2 bytes, and flips the bytes)
         _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_F_STAT_REG.tochar(), "\xFF\xFF");
@@ -182,6 +181,7 @@ class StubbedHardwareTests extends ImpTestCase {
                 local expectedErr = format("Error reading reg: 0x%02X Err: reg bit not ready.", MAX17055_F_STAT_REG);
                 assertEqual(err, expectedErr, "DNR bit not ready error in init did not create expected error");
 
+                _cleari2cBuffers();
                 return resolve("Init with DNR bit not ready passed expected error to callback");
             }.bindenv(this))
         }.bindenv(this))
@@ -197,7 +197,7 @@ class StubbedHardwareTests extends ImpTestCase {
         // Don't set any read data for MAX17055_HIB_CFG_REG to cause error
         
         // Set readbuffer values
-        // MAX17055_V_CELL_REG to 0x0200 (lib always reads 2 bytes, and flips the bytes)
+        // MAX17055_STATUS_REG to 0x0200 (lib always reads 2 bytes, and flips the bytes)
         _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_STATUS_REG.tochar(), "\x02\x00");
         // MAX17055_F_STAT_REG to 0x0000 (lib always reads 2 bytes, and flips the bytes)
         _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_F_STAT_REG.tochar(), "\x00\x00");
@@ -217,6 +217,7 @@ class StubbedHardwareTests extends ImpTestCase {
                 local expectedErr = format("Error reading reg: 0x%02X Err: %i", MAX17055_HIB_CFG_REG, -100);
                 assertEqual(err, expectedErr, "Hibernate configuration i2c error in init did not create expected error");
 
+                _cleari2cBuffers();
                 return resolve("Init hibernate configuration i2c error passed expected error to callback");
             }.bindenv(this))
         }.bindenv(this))
@@ -232,7 +233,7 @@ class StubbedHardwareTests extends ImpTestCase {
         // Don't set any read data for MAX17055_MODEL_CFG_REG to cause error
         
         // Set readbuffer values
-        // MAX17055_V_CELL_REG to 0x0200 (lib always reads 2 bytes, and flips the bytes)
+        // MAX17055_STATUS_REG to 0x0200 (lib always reads 2 bytes, and flips the bytes)
         _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_STATUS_REG.tochar(), "\x02\x00");
         // MAX17055_F_STAT_REG to 0x0000 (lib always reads 2 bytes, and flips the bytes)
         _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_F_STAT_REG.tochar(), "\x00\x00");
@@ -254,6 +255,7 @@ class StubbedHardwareTests extends ImpTestCase {
                 local expectedErr = format("Error reading reg: 0x%02X Err: %i", MAX17055_MODEL_CFG_REG, -100);
                 assertEqual(err, expectedErr, "POR i2c error in init did not create expected error");
 
+                _cleari2cBuffers();
                 return resolve("Init with POR i2c error passed expected error to callback");
             }.bindenv(this))
         }.bindenv(this))
@@ -268,7 +270,7 @@ class StubbedHardwareTests extends ImpTestCase {
         // Test that i2c error bubbles up when MAX17055_MODEL_CFG_REG times out, never reaches ready state
         
         // Set readbuffer values
-        // MAX17055_V_CELL_REG to 0x0200 (lib always reads 2 bytes, and flips the bytes)
+        // MAX17055_STATUS_REG to 0x0200 (lib always reads 2 bytes, and flips the bytes)
         _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_STATUS_REG.tochar(), "\x02\x00");
         // MAX17055_F_STAT_REG to 0x0000 (lib always reads 2 bytes, and flips the bytes)
         _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_F_STAT_REG.tochar(), "\x00\x00");
@@ -292,23 +294,204 @@ class StubbedHardwareTests extends ImpTestCase {
                 local expectedErr = format("Error reading reg: 0x%02X Err: reg bit not ready.", MAX17055_MODEL_CFG_REG);
                 assertEqual(err, expectedErr, "Model config i2c error in init did not create expected error");
 
+                _cleari2cBuffers();
                 return resolve("Init with Model config i2c error passed expected error to callback");
             }.bindenv(this))
         }.bindenv(this))
     }
 
-    // Init tests
+    function testInitHibCfgVerify1Fail() {
+        // Note: Limitation of stubbed class, all read values are set before method is called, if inside the 
+        // method a value is updated and read again (ie set reg bit called on the same register 2X) the second
+        // read will not reflect the updates made by the setter inside the function.
+        _cleari2cBuffers();
 
-    // Failures 
-        // MAX17055_HIB_CFG_REG write verify fails
-            // try/catch causes error (clear value for MAX17055_STATUS_REG, so read fails here);
-            // read MAX17055_STATUS_REG, mask 0xFFFD, 2x+ verify that after the write that the values match
-            // TODO - look into testing _writeVerify/_verify method by it's self
+        // Test that _writeVerify error bubbles up i2c when MAX17055_STATUS_REG
+        
+        // Set readbuffer values
+        // MAX17055_STATUS_REG to 0x0200 (lib always reads 2 bytes, and flips the bytes)
+        _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_STATUS_REG.tochar(), "\x02\x00");
+        // MAX17055_F_STAT_REG to 0xFFFF (lib always reads 2 bytes, and flips the bytes)
+        _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_F_STAT_REG.tochar(), "\xFF\xFF");
+        // MAX17055_HIB_CFG_REG to 0xFFFF (lib always reads 2 bytes, and flips the bytes)
+        _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_HIB_CFG_REG.tochar(), "\xFF\xFF");
+        // MAX17055_MODEL_CFG_REG to 0x0000 (lib always reads 2 bytes, and flips the bytes)
+        _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_MODEL_CFG_REG.tochar(), "\x00\x00");
 
-    // Successes
-        // status bit no need to initialize
-        // successfull init if status bit triggers init seq (check write buffer at end to see if it matches expected)
+        return Promise(function(resolve, reject) {
+            local settings = {
+            "desCap"       : 2000, // mAh
+            "senseRes"     : 0.01, // ohms
+            "chrgTerm"     : 20,   // mA
+            "emptyVTarget" : 3.3,  // V
+            "recoveryV"    : 3.88, // V
+            "chrgV"        : MAX17055_V_CHRG_4_2,
+            "battType"     : MAX17055_BATT_TYPE.LiCoO2
+            }
 
+            _fg.init(settings, function(err) {
+                local expectedErr = format("Error reading reg: 0x%02X Err: -100", MAX17055_STATUS_REG);
+                assertEqual(err, expectedErr, "Write/verify status reg i2c error in init did not create expected error");
+
+                _cleari2cBuffers();
+                return resolve("Init with write/verify status reg i2c error passed expected error to callback");
+            }.bindenv(this))
+            
+            // MAX17055_F_STAT_REG to 0x0000 (lib always reads 2 bytes, and flips the bytes)
+            _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_F_STAT_REG.tochar(), "\x00\x00");
+            // Delete MAX17055_STATUS_REG from read buffer to cause error in write/verify
+            if (MAX17055_STATUS_REG.tochar() in _i2c._readResp[MAX17055_DEFAULT_I2C_ADDR]) {
+                _i2c._readResp[MAX17055_DEFAULT_I2C_ADDR].rawdelete(MAX17055_STATUS_REG.tochar())
+            } 
+        }.bindenv(this))
+    }
+
+    function testInitHibCfgVerify2Fail() {
+        // Note: Limitation of stubbed class, all read values are set before method is called, if inside the 
+        // method a value is updated and read again (ie set reg bit called on the same register 2X) the second
+        // read will not reflect the updates made by the setter inside the function.
+        _cleari2cBuffers();
+
+        // Test that _writeVerify error bubbles up when MAX17055_STATUS_REG times out, never reaches ready state
+        
+        // Set readbuffer values
+        // MAX17055_STATUS_REG to 0x0200 (lib always reads 2 bytes, and flips the bytes)
+        _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_STATUS_REG.tochar(), "\x02\x00");
+        // MAX17055_F_STAT_REG to 0x0000 (lib always reads 2 bytes, and flips the bytes)
+        _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_F_STAT_REG.tochar(), "\x00\x00");
+        // MAX17055_HIB_CFG_REG to 0xFFFF (lib always reads 2 bytes, and flips the bytes)
+        _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_HIB_CFG_REG.tochar(), "\xFF\xFF");
+        // MAX17055_MODEL_CFG_REG to 0x0000 (lib always reads 2 bytes, and flips the bytes)
+        _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_MODEL_CFG_REG.tochar(), "\x00\x00");
+
+        return Promise(function(resolve, reject) {
+            local settings = {
+            "desCap"       : 2000, // mAh
+            "senseRes"     : 0.01, // ohms
+            "chrgTerm"     : 20,   // mA
+            "emptyVTarget" : 3.3,  // V
+            "recoveryV"    : 3.88, // V
+            "chrgV"        : MAX17055_V_CHRG_4_2,
+            "battType"     : MAX17055_BATT_TYPE.LiCoO2
+            }
+
+            _fg.init(settings, function(err) {
+                local expectedErr = format("Error write verify to reg: 0x%02X failed. Verification did not match write.", MAX17055_STATUS_REG);
+                assertEqual(err, expectedErr, "Write/verify status reg timeout error in init did not create expected error");
+
+                _cleari2cBuffers();
+                return resolve("Init with write/verify status reg timeout error passed expected error to callback");
+            }.bindenv(this))
+            
+        }.bindenv(this))
+    }
+
+    function testInitSuccess1() {
+        // Note: Limitation of stubbed class, all read values are set before method is called, if inside the 
+        // method a value is updated and read again (ie set reg bit called on the same register 2X) the second
+        // read will not reflect the updates made by the setter inside the function.
+        _cleari2cBuffers();
+
+        // POR Status bit set, no init needed flow
+        
+        // Set readbuffer values
+        // MAX17055_STATUS_REG to 0x0000 (lib always reads 2 bytes, and flips the bytes)
+        _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_STATUS_REG.tochar(), "\x00\x00");
+
+        return Promise(function(resolve, reject) {
+            local settings = {
+            "desCap"       : 2000, // mAh
+            "senseRes"     : 0.01, // ohms
+            "chrgTerm"     : 20,   // mA
+            "emptyVTarget" : 3.3,  // V
+            "recoveryV"    : 3.88, // V
+            "chrgV"        : MAX17055_V_CHRG_4_2,
+            "battType"     : MAX17055_BATT_TYPE.LiCoO2
+            }
+
+            _fg.init(settings, function(err) {
+                assertEqual(err, null, "Unexpected init error detected");
+
+                _cleari2cBuffers();
+                return resolve("Init successfull, no error passed to callback");
+            }.bindenv(this))
+        }.bindenv(this))
+    }
+
+    function testInitSuccess2() {
+        // Note: Limitation of stubbed class, all read values are set before method is called, if inside the 
+        // method a value is updated and read again (ie set reg bit called on the same register 2X) the second
+        // read will not reflect the updates made by the setter inside the function.
+        _cleari2cBuffers();
+
+        // POR Status bit not set, full init flow needed
+        local hibCfg = "\xFF\xFF";
+
+        // Set readbuffer values
+        // MAX17055_STATUS_REG to 0x0200 (lib always reads 2 bytes, and flips the bytes)
+        _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_STATUS_REG.tochar(), "\x02\x00");
+        // MAX17055_F_STAT_REG to 0x0000 (lib always reads 2 bytes, and flips the bytes)
+        _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_F_STAT_REG.tochar(), "\xFF\xFF");
+        // MAX17055_HIB_CFG_REG to 0xFFFF (lib always reads 2 bytes, and flips the bytes)
+        _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_HIB_CFG_REG.tochar(), hibCfg);
+        // MAX17055_MODEL_CFG_REG to 0x0000 (lib always reads 2 bytes, and flips the bytes)
+        _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_MODEL_CFG_REG.tochar(), "\xFF\xFF");
+
+        // Toggle read responses after i2c writes 
+        _i2c._setWriteWatcher(MAX17055_DEFAULT_I2C_ADDR, MAX17055_MODEL_CFG_REG.tochar(), function() {
+            // MAX17055_MODEL_CFG_REG to 0x0000 (lib always reads 2 bytes, and flips the bytes)
+            _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_MODEL_CFG_REG.tochar(), "\x00\x00");
+        }.bindenv(this));
+        _i2c._setWriteWatcher(MAX17055_DEFAULT_I2C_ADDR, MAX17055_HIB_CFG_REG.tochar(), function() {
+            // MAX17055_STATUS_REG to 0x0000 (lib always reads 2 bytes, and flips the bytes)
+            _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_STATUS_REG.tochar(), "\x00\x00");
+        }.bindenv(this));
+
+        return Promise(function(resolve, reject) {
+            local settings = {
+            "desCap"       : 2000, // mAh
+            "senseRes"     : 0.01, // ohms
+            "chrgTerm"     : 20,   // mA
+            "emptyVTarget" : 3.3,  // V
+            "recoveryV"    : 3.88, // V
+            "chrgV"        : MAX17055_V_CHRG_4_2,
+            "battType"     : MAX17055_BATT_TYPE.LiCoO2
+            }
+
+            _fg.init(settings, function(err) {
+                // Check class vars set to expected values
+                local exCapLSB  = 0.5;
+                local exCurrLSB = 0.15625;
+
+                // Check write buffer for all i2c writes
+                local exWB = MAX17055_SOFT_WAKE_CMD_REG.tochar() + "\x90\x00" +
+                             MAX17055_HIB_CFG_REG.tochar() + "\x00\x00" +
+                             MAX17055_SOFT_WAKE_CMD_REG.tochar() + "\x00\x00" +
+                             MAX17055_DESIGN_CAP_REG.tochar() + "\xA0\x0F" +
+                             MAX17055_DQ_ACC_REG.tochar() + "\x7D\x00" +
+                             MAX17055_I_CHR_TERM_REG.tochar() + "\x80\x00" +
+                             MAX17055_V_EMPTY_REG.tochar() + "\x61\xA5" + 
+                             MAX17055_DP_ACC_REG.tochar() + "\x63\x05" + 
+                             MAX17055_MODEL_CFG_REG.tochar() + "\x00\x80" + 
+                             MAX17055_HIB_CFG_REG.tochar() + hibCfg + 
+                             MAX17055_STATUS_REG.tochar() + "\x00\x00"; 
+
+                local wb = _i2c._getWriteBuffer(MAX17055_DEFAULT_I2C_ADDR);
+
+                assertEqual(format("%.1f", exCapLSB), format("%.1f", _fg._capacityLSB), format("Capacity LSB mismatch: expected %.1f, acutal %.1f", exCapLSB, _fg._capacityLSB));
+                assertEqual(format("%.5f", exCurrLSB), format("%.5f", _fg._currLSB), format("Current LSB mismatch: expected %.1f, acutal %.1f", exCurrLSB, _fg._currLSB));
+                assertEqual(exWB, wb, "Write buffer did not match expected write buffer.");
+
+                _cleari2cBuffers();
+                return resolve("Init success test passed");
+            }.bindenv(this))
+
+            // Toggle MAX17055_F_STAT_REG so _regReady goes through at least one check.
+            // MAX17055_F_STAT_REG to 0x0000 (lib always reads 2 bytes, and flips the bytes)
+            _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_F_STAT_REG.tochar(), "\x00\x00");
+        }.bindenv(this))
+    }
+    
     function testGetVoltage() {
         // Note: Limitation of stubbed class, all read values are set before method is called, if inside the 
         // method a value is updated and read again (ie set reg bit called on the same register 2X) the second
@@ -584,5 +767,9 @@ class StubbedHardwareTests extends ImpTestCase {
 
         _cleari2cBuffers();
         return "clearThresholds test passed";
+    }
+
+    function tearDown() {
+        return "Stubbed hardware tests finished.";
     }
 }

--- a/tests/StubbedI2C.device.test.nut
+++ b/tests/StubbedI2C.device.test.nut
@@ -1,0 +1,353 @@
+// MIT License
+//
+// Copyright 2019 Electric Imp
+//
+// SPDX-License-Identifier: MIT
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO
+// EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+// OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+// ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+// OTHER DEALINGS IN THE SOFTWARE.
+
+@include __PATH__+ "/StubbedI2C.device.nut"
+
+class StubbedHardwareTests extends ImpTestCase {
+
+    _i2c = null;
+    _fg  = null;
+
+    function _cleari2cBuffers() {
+        // Clear all buffers
+        _i2c._clearWriteBuffer();
+        _i2c._clearReadResp();
+    }
+
+    function setUp() {
+        _i2c = StubbedI2C();
+        _i2c.configure(CLOCK_SPEED_400_KHZ);
+        _fg = MAX17055(_i2c);
+        return "Stubbed hardware test setup complete.";
+    }  
+
+    function testConstructorDefaultParams() {
+        assertEqual(MAX17055_DEFAULT_I2C_ADDR, _fg._addr, "Defult i2c address did not match expected");
+        return "Constructor default params test complete.";
+    }
+
+    function testConstructorOptionalParams() {
+        local customAddr = 0xBA;
+        local _fg = MAX17055(_i2c, customAddr);
+        assertEqual(customAddr, _fg._addr, "Non default i2c address did not match expected");
+        return "Constructor optional params test complete.";
+    }
+
+    function tearDown() {
+        return "Stubbed hardware tests finished.";
+    }
+
+    // function testInit() {
+    //     // Init tests
+
+    //     // Failures 
+    //     // bad params
+    //     // status reg / bit not ready
+    //     // error reading F_STAT_REG
+    //     // error writing to registers (or desCap not an integer)??
+    //     // mode config reg / bit not ready
+    //     // write error (write verify reg)
+
+    //     // Successes
+    //     // status bit no need to initialize
+    //     // successfull init if status bit is ok
+    // }
+
+    function testGetVoltage() {
+        // Note: Limitation of stubbed class, all read values are set before method is called, if inside the 
+        // method a value is updated and read again (ie set reg bit called on the same register 2X) the second
+        // read will not reflect the updates made by the setter inside the function.
+        _cleari2cBuffers();
+        
+        // Set readbuffer values
+        // MAX17055_V_CELL_REG to 0xFFFF (lib always reads 2 bytes, and flips the bytes)
+        _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_V_CELL_REG.tochar(), "\xFF\xFF");
+        
+        local expected = 5.11992;
+        local actual   = _fg.getVoltage();
+        local failMsg = format("getVoltage test failed actual %.5f did not match expected %.5f", actual, expected);
+        assertEqual(format("%.5f", expected), format("%.5f", actual), failMsg);
+
+        _cleari2cBuffers();
+        return "getVoltage test passed";
+    }
+
+    function testGetCurrent() {
+        // Note: Limitation of stubbed class, all read values are set before method is called, if inside the 
+        // method a value is updated and read again (ie set reg bit called on the same register 2X) the second
+        // read will not reflect the updates made by the setter inside the function.
+        _cleari2cBuffers();
+        
+        // Set _currLSB value (for a 0.01 ohm sense resistor)
+        _fg._currLSB = 0.15625;
+
+        // Set readbuffer values
+        // MAX17055_CURRENT_REG to 0xFFFF (lib always reads 2 bytes, and flips the bytes)
+        _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_CURRENT_REG.tochar(), "\xFF\xFF");
+        
+        local expected = -0.15625;
+        local actual   = _fg.getCurrent();
+        local failMsg = format("getCurrent test failed actual %.5f did not match expected %.5f", actual, expected);
+        assertEqual(format("%.5f", expected), format("%.5f", actual), failMsg);
+
+        _cleari2cBuffers();
+        return "getCurrent test passed";
+    }
+
+    function testGetTimeTilEmpty() {
+        // Note: Limitation of stubbed class, all read values are set before method is called, if inside the 
+        // method a value is updated and read again (ie set reg bit called on the same register 2X) the second
+        // read will not reflect the updates made by the setter inside the function.
+        _cleari2cBuffers();
+        
+        // Set readbuffer values
+        // MAX17055_TTE_REG to 0xFFFF (lib always reads 2 bytes, and flips the bytes)
+        _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_TTE_REG.tochar(), "\xFF\xFF");
+        
+        local expected = 102.3984;
+        local actual   = _fg.getTimeTilEmpty();
+        local failMsg = format("getTimeTilEmpty test failed actual %.4f did not match expected %.4f", actual, expected);
+        assertEqual(format("%.4f", expected), format("%.4f", actual), failMsg);
+
+        _cleari2cBuffers();
+        return "getTimeTilEmpty test passed";
+    }
+
+    function testGetTimeTilFull() {
+        // Note: Limitation of stubbed class, all read values are set before method is called, if inside the 
+        // method a value is updated and read again (ie set reg bit called on the same register 2X) the second
+        // read will not reflect the updates made by the setter inside the function.
+        _cleari2cBuffers();
+        
+        // Set readbuffer values
+        // MAX17055_TTF_REG to 0xFFFF (lib always reads 2 bytes, and flips the bytes)
+        _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_TTF_REG.tochar(), "\xFF\xFF");
+        
+        local expected = 102.3984;
+        local actual   = _fg.getTimeTilFull();
+        local failMsg = format("getTimeTilFull test failed actual %.4f did not match expected %.4f", actual, expected);
+        assertEqual(format("%.4f", expected), format("%.4f", actual), failMsg);
+
+        _cleari2cBuffers();
+        return "getTimeTilFull test passed";
+    }
+
+    function testGetAvgCurrent() {
+        // Note: Limitation of stubbed class, all read values are set before method is called, if inside the 
+        // method a value is updated and read again (ie set reg bit called on the same register 2X) the second
+        // read will not reflect the updates made by the setter inside the function.
+        _cleari2cBuffers();
+        
+        // Set _currLSB value (for a 0.01 ohm sense resistor)
+        _fg._currLSB = 0.15625;
+
+        // Set readbuffer values
+        // MAX17055_AVG_CURRENT_REG to 0xFFFF (lib always reads 2 bytes, and flips the bytes)
+        _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_AVG_CURRENT_REG.tochar(), "\xFF\xFF");
+        
+        local expected = -0.15625;
+        local actual   = _fg.getAvgCurrent();
+        local failMsg = format("getAvgCurrent test failed actual %.5f did not match expected %.5f", actual, expected);
+        assertEqual(format("%.5f", expected), format("%.5f", actual), failMsg);
+
+        _cleari2cBuffers();
+        return "getAvgCurrent test passed";
+    }
+
+    function testGetAvgCapacity() {
+        // Note: Limitation of stubbed class, all read values are set before method is called, if inside the 
+        // method a value is updated and read again (ie set reg bit called on the same register 2X) the second
+        // read will not reflect the updates made by the setter inside the function.
+        _cleari2cBuffers();
+        
+        // Set _currLSB value (for a 0.01 ohm sense resistor)
+        _fg._capacityLSB = 0.5;
+
+        // Set readbuffer values
+        // MAX17055_AV_CAP_REG to 0xFFFF (lib always reads 2 bytes, and flips the bytes)
+        _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_AV_CAP_REG.tochar(), "\xFF\xFF");
+        
+        local expected = -0.5;
+        local actual   = _fg.getAvgCapacity();
+        local failMsg = format("getAvgCapacity test failed actual %.1f did not match expected %.1f", actual, expected);
+        assertEqual(format("%.1f", expected), format("%.1f", actual), failMsg);
+
+        _cleari2cBuffers();
+        return "getAvgCapacity test passed";
+    }
+
+    function testDeviceRev() {
+        // Note: Limitation of stubbed class, all read values are set before method is called, if inside the 
+        // method a value is updated and read again (ie set reg bit called on the same register 2X) the second
+        // read will not reflect the updates made by the setter inside the function.
+        _cleari2cBuffers();
+        
+        // Set readbuffer values
+        // MAX17055_DEV_NAME_REG to 0x1040 (lib always reads 2 bytes, and flips the bytes)
+        _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_DEV_NAME_REG.tochar(), "\x10\x40");
+        
+        local expected = 0x4010;
+        local actual   = _fg.getDeviceRev();
+        local failMsg = format("getDeviceRev test failed actual %i did not match expected %i", actual, expected);
+        assertEqual(format("%i", expected), format("%i", actual), failMsg);
+
+        _cleari2cBuffers();
+        return "getDeviceRev test passed";
+    }
+
+    function testGetSOC() {
+        // Note: Limitation of stubbed class, all read values are set before method is called, if inside the 
+        // method a value is updated and read again (ie set reg bit called on the same register 2X) the second
+        // read will not reflect the updates made by the setter inside the function.
+        _cleari2cBuffers();
+        
+        // Set _currLSB value (for a 0.01 ohm sense resistor)
+        _fg._capacityLSB = 0.5;
+
+        // Set readbuffer values
+        // MAX17055_REP_SOC_REG to 0xFFFF (lib always reads 2 bytes, and flips the bytes)
+        // MAX17055_REP_CAP_REG to 0xFFFF (lib always reads 2 bytes, and flips the bytes)
+        _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_REP_SOC_REG.tochar(), "\xFF\xFF");
+        _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_REP_CAP_REG.tochar(), "\xFF\xFF");
+        
+        local exSOC  = 255.9961;
+        local exCap  = -0.5;
+        local actual = _fg.getStateOfCharge();
+        local failSOCMsg = format("getSOC test failed actual SOC %.4f did not match expected SOC %.4f", actual.percent, exSOC);
+        local failCapMsg = format("getSOC test failed actual capacity %i did not match expected capacity %i", actual.capacity, exCap);
+        assertEqual(format("%i", exSOC), format("%i", actual.percent), failSOCMsg);
+        assertEqual(format("%i", exCap), format("%i", actual.capacity), failCapMsg);
+
+        _cleari2cBuffers();
+        return "getSOC test passed";        
+    }
+
+    function testGetTemperature() {
+        // Note: Limitation of stubbed class, all read values are set before method is called, if inside the 
+        // method a value is updated and read again (ie set reg bit called on the same register 2X) the second
+        // read will not reflect the updates made by the setter inside the function.
+        _cleari2cBuffers();
+        
+        // Set readbuffer values
+        // MAX17055_TEMP_REG to 0xFF7F (lib always reads 2 bytes, and flips the bytes)
+        _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_TEMP_REG.tochar(), "\xFF\x7F");
+        
+        local expected = 127.996;
+        local actual   = _fg.getTemperature();
+        local failMsg = format("getTemperature test failed actual %.3f did not match expected %.3f", actual, expected);
+        assertEqual(format("%.3f", expected), format("%.3f", actual), failMsg);
+
+        _cleari2cBuffers();
+        return "getTemperature test passed";
+    }
+
+    function testGetAlertStatus() {
+        // Note: Limitation of stubbed class, all read values are set before method is called, if inside the 
+        // method a value is updated and read again (ie set reg bit called on the same register 2X) the second
+        // read will not reflect the updates made by the setter inside the function.
+        _cleari2cBuffers();
+        
+        // Set readbuffer values
+        // MAX17055_STATUS_REG to 0x8A88 (lib always reads 2 bytes, and flips the bytes)
+        _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_STATUS_REG.tochar(), "\x8A\x88");
+        
+        local status = _fg.getAlertStatus();
+        local failMsg = "getAlertStatus test failed %s did not match expected";
+        assertTrue(status.powerOnReset, format(failMsg, "powerOnReset"));
+        assertTrue(status.battRemovalDetected, format(failMsg, "battRemovalDetected"));
+        assertTrue(status.battInsertDetected, format(failMsg, "battInsertDetected"));
+        assertTrue(status.battAbsent, format(failMsg, "battAbsent"));
+        assertTrue(status.chargeStatePercentChange, format(failMsg, "chargeStatePercentChange"));
+
+        _cleari2cBuffers();
+        return "getAlertStatus test passed";
+    }
+
+    function testClearAlertStatus() {
+        // Note: Limitation of stubbed class, all read values are set before method is called, if inside the 
+        // method a value is updated and read again (ie set reg bit called on the same register 2X) the second
+        // read will not reflect the updates made by the setter inside the function.
+        _cleari2cBuffers();
+        
+        _fg.clearStatusAlerts();
+
+        // Register (MAX17055_STATUS_REG 0x00) and data (0x0000)
+        local expected = "\x00\x00\x00";
+        local wb = _i2c._getWriteBuffer(MAX17055_DEFAULT_I2C_ADDR);
+        assertEqual(expected, wb, "clearStatusAlerts write buffer did not match expected");
+
+        _cleari2cBuffers();
+        return "clearStatusAlerts test passed";
+    }
+
+    function testEnableAlerts() {
+        // Note: Limitation of stubbed class, all read values are set before method is called, if inside the 
+        // method a value is updated and read again (ie set reg bit called on the same register 2X) the second
+        // read will not reflect the updates made by the setter inside the function.
+        _cleari2cBuffers();
+        
+        // Set readbuffer values
+        // MAX17055_CONFIG_REG to 0xF9FF (0,1,2) (lib always reads 2 bytes, and flips the bytes)
+        // MAX17055_CONFIG_2_REG to 0x7FFF (7) (lib always reads 2 bytes, and flips the bytes)
+        _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_CONFIG_REG.tochar(), "\xF9\xFF");
+        _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_CONFIG_2_REG.tochar(), "\x7F\xFF");
+        
+        _fg.enableAlerts({
+            "enBattRemove" : false,
+            "enBattInsert" : true,
+            "enAlertPin" : false,
+            "enChargeStatePercentChange" : true
+        });
+
+        // Get Write Buffer 
+        local expWB = MAX17055_CONFIG_REG.tochar() + "\xFA\xFF" + MAX17055_CONFIG_2_REG.tochar() + "\xFF\xFF";
+        local wb = _i2c._getWriteBuffer(MAX17055_DEFAULT_I2C_ADDR);
+
+        assertEqual(expWB, wb, "enableAlerts write buffer did not match expected");
+
+        _cleari2cBuffers();
+        return "enableAlerts test passed";
+    }
+
+    function testClearThresholds() {
+        // Note: Limitation of stubbed class, all read values are set before method is called, if inside the 
+        // method a value is updated and read again (ie set reg bit called on the same register 2X) the second
+        // read will not reflect the updates made by the setter inside the function.
+        _cleari2cBuffers();
+        
+        _fg.clearThresholds();
+
+        local expected = MAX17055_V_ALRT_TH_REG.tochar() + "\x00\xFF" +
+                         MAX17055_T_ALRT_TH_REG.tochar() + "\x80\x7F" +
+                         MAX17055_S_ALRT_TH_REG.tochar() + "\x00\xFF" +
+                         MAX17055_I_ALRT_TH_REG.tochar() + "\x80\x7F";
+
+        local wb = _i2c._getWriteBuffer(MAX17055_DEFAULT_I2C_ADDR);
+
+        assertEqual(expected, wb, "clearThresholds write buffer did not match expected");
+
+        _cleari2cBuffers();
+        return "clearThresholds test passed";
+    }
+}

--- a/tests/StubbedI2C.device.test.nut
+++ b/tests/StubbedI2C.device.test.nut
@@ -693,10 +693,8 @@ class StubbedHardwareTests extends ImpTestCase {
         local status = _fg.getAlertStatus();
         local failMsg = "getAlertStatus test failed %s did not match expected";
         assertTrue(status.powerOnReset, format(failMsg, "powerOnReset"));
-        assertTrue(status.battRemovalDetected, format(failMsg, "battRemovalDetected"));
-        assertTrue(status.battInsertDetected, format(failMsg, "battInsertDetected"));
-        assertTrue(status.battAbsent, format(failMsg, "battAbsent"));
         assertTrue(status.chargeStatePercentChange, format(failMsg, "chargeStatePercentChange"));
+        assertTrue(status.raw, format(failMsg, "raw"));
 
         _cleari2cBuffers();
         return "getAlertStatus test passed";
@@ -728,18 +726,16 @@ class StubbedHardwareTests extends ImpTestCase {
         // Set readbuffer values
         // MAX17055_CONFIG_REG to 0xF9FF (0,1,2) (lib always reads 2 bytes, and flips the bytes)
         // MAX17055_CONFIG_2_REG to 0x7FFF (7) (lib always reads 2 bytes, and flips the bytes)
-        _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_CONFIG_REG.tochar(), "\xF9\xFF");
+        _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_CONFIG_REG.tochar(), "\xFD\xFF");
         _i2c._setReadResp(MAX17055_DEFAULT_I2C_ADDR, MAX17055_CONFIG_2_REG.tochar(), "\x7F\xFF");
         
         _fg.enableAlerts({
-            "enBattRemove" : false,
-            "enBattInsert" : true,
             "enAlertPin" : false,
             "enChargeStatePercentChange" : true
         });
 
         // Get Write Buffer 
-        local expWB = MAX17055_CONFIG_REG.tochar() + "\xFA\xFF" + MAX17055_CONFIG_2_REG.tochar() + "\xFF\xFF";
+        local expWB = MAX17055_CONFIG_REG.tochar() + "\xF9\xFF" + MAX17055_CONFIG_2_REG.tochar() + "\xFF\xFF";
         local wb = _i2c._getWriteBuffer(MAX17055_DEFAULT_I2C_ADDR);
 
         assertEqual(expWB, wb, "enableAlerts write buffer did not match expected");


### PR DESCRIPTION
- fixed bug in enableAlerts
- removed alerts not supported by current hardware (breakout boards)
- improved init error messaging
- added tests
- updated version number